### PR TITLE
Support plugin options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ An NPM module to convert currency digits into written Arabic words
 | --------- | ------------- | ------ | ----------------------------------- |
 | currency  | "SDG"         | String | the currency name                   |
 | startWith | "فقط"         | String | the first word before currency text |
-| endWith   | "لا غير"      | String | the last word before currency text  |
+| endWith   | "لا غير"      | String | the last word after currency text  |
 
 ## Supported currencies:
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,55 @@
 # TafgeetJS
+
 An NPM module to convert currency digits into written Arabic words
 [https://www.npmjs.com/package/tafgeetjs](https://www.npmjs.com/package/tafgeetjs)
 
 ## How to use:
+
 ### Install
+
 `npm install tafgeetjs`
+
 ### Usage
-`var Tafgeet = require('tafgeetjs');`
 
-`var stringText = new Tafgeet(556563.20, 'SDG').parse();` this will produce: 'فقط خمسمائة وستة وخمسون ألف وخمسمائة وثلاثة وستون جنيه سوداني وعشرون قرش لا غير'.
+`var Tafgeet = require('tafgeetjs', YOUR_OPTIONS);`
 
-## Supported currencies: 
-- SDG (Sudanese Pound) - *Default*
+`var stringText = new Tafgeet(556563.20, { currency: 'SDG' }).parse();` this will produce: 'فقط خمسمائة وستة وخمسون ألف وخمسمائة وثلاثة وستون جنيه سوداني وعشرون قرش لا غير'.
+
+`var stringText = new Tafgeet(556563.20, { currency: 'SDG', startWith: null }).parse();` this will produce: 'خمسمائة وستة وخمسون ألف وخمسمائة وثلاثة وستون جنيه سوداني وعشرون قرش لا غير'.
+
+`var stringText = new Tafgeet(556563.20, { currency: 'SDG', startWith: null, endtWith: null }).parse();` this will produce: 'خمسمائة وستة وخمسون ألف وخمسمائة وثلاثة وستون جنيه سوداني وعشرون قرش'.
+
+`var stringText = new Tafgeet(556563, { currency: null, startWith: null, endtWith: null }).parse();` this will produce: 'خمسمائة وستة وخمسون ألف وخمسمائة وثلاثة وستون'.
+
+## Options
+
+|           | Default Value | Type   | Description                         |
+| --------- | ------------- | ------ | ----------------------------------- |
+| currency  | "SDG"         | String | the currency name                   |
+| startWith | "فقط"         | String | the first word before currency text |
+| endWith   | "لا غير"      | String | the last word before currency text  |
+
+## Supported currencies:
+
+- SDG (Sudanese Pound) - _Default_
 - SAR (Saudi Riyal)
 - QAR (Qatari Riyal)
 - AED (Emarati Dirham)
 - EGP (Egyptian Pound)
 - USD (US Dollar)
-- TND (Tunisian Dinar) - *by [@atefBB](https://github.com/atefBB)*
-- AUD (Australian Dollar) - *by [@mohamedabbasos](https://github.com/mohamedabbasos)*
-- TRY (Turkish Lira) - *by [@lokutech](https://github.com/lokutech)*
+- TND (Tunisian Dinar) - _by [@atefBB](https://github.com/atefBB)_
+- AUD (Australian Dollar) - _by [@mohamedabbasos](https://github.com/mohamedabbasos)_
+- TRY (Turkish Lira) - _by [@lokutech](https://github.com/lokutech)_
 
-## TODOs: 
+## TODOs:
+
 - Support more currencies
 - Better grammer support
 - ~~Add test cases~~
 
 ## Angular Demo
+
 TafgeetJS NPM module could also be imported using ES6 import syntax, below are links to an Angular example project:
 
-- [Project Repo](https://github.com/mmahgoub/tafgeetjs-angular-demo/) 
+- [Project Repo](https://github.com/mmahgoub/tafgeetjs-angular-demo/)
 - [Live Demo](https://mmahgoub.github.io/tafgeetjs-angular-demo/)

--- a/index.js
+++ b/index.js
@@ -5,8 +5,16 @@
  * @author Mohammed Mahgoub <mmahgoub@gmail.com>
  */
 
-function Tafgeet(digit) {
-  var currency = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "SDG";
+function Tafgeet(digit, options) {
+  this.computedOptions = {
+    // first we put the defaults
+    currency: "SDG",
+    startWith: "فقط",
+    endWith: "لا غير",
+    // then overwrite with user's options
+    ...options
+  }
+
   
   //Split fractions
   var splitted = digit.toString().split(".");
@@ -21,7 +29,7 @@ function Tafgeet(digit) {
         //trim it
         var trimmed = Array.from(splitted[1]);
         this.fraction = "";
-        for (var index = 0; index < this.currencies[currency].decimals; index++) {
+        for (var index = 0; index < this.currencies[this.computedOptions.currency].decimals; index++) {
           this.fraction += trimmed[index];
         }
       }
@@ -30,7 +38,6 @@ function Tafgeet(digit) {
     }    
   }
   this.digit = splitted[0];
-  this.currency = currency;
 }
 
 Tafgeet.prototype.parse = function () {
@@ -78,7 +85,9 @@ Tafgeet.prototype.parse = function () {
   }
 
   var str = "";
-  str += "فقط ";
+  if(this.computedOptions.startWith) {
+    str += this.computedOptions.startWith + " ";
+  }
 
   if (this.length() >= 1 && this.length() <= 3) {
     str += this.read(this.digit);
@@ -98,11 +107,11 @@ Tafgeet.prototype.parse = function () {
     }
   }
 
-  if (this.currency != "") {
+  if (this.computedOptions.currency != "") {
     if (this.digit >= 3 && this.digit <= 10) {
-      str += " " + this.currencies[this.currency].plural;
+      str += " " + this.currencies[this.computedOptions.currency].plural;
     } else {
-      str += " " + this.currencies[this.currency].singular;
+      str += " " + this.currencies[this.computedOptions.currency].singular;
     }
     if (this.fraction != 0) {
       if (this.digit >= 3 && this.digit <= 10) {
@@ -110,18 +119,20 @@ Tafgeet.prototype.parse = function () {
           " و" +
           this.read(this.fraction) +
           " " +
-          this.currencies[this.currency].fractions;
+          this.currencies[this.computedOptions.currency].fractions;
       } else {
         str +=
           " و" +
           this.read(this.fraction) +
           " " +
-          this.currencies[this.currency].fraction;
+          this.currencies[this.computedOptions.currency].fraction;
       }
     }
   }
-
-  str += " لا غير";
+  
+  if(this.computedOptions.endtWith) {
+    str += " " + this.computedOptions.endtWith;
+  }
   return str;
 };
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Tafgeet(digit, options) {
     startWith: "فقط",
     endWith: "لا غير",
     // then overwrite with user's options
-    ...options
+    ...(options || {})
   }
 
   

--- a/index.js
+++ b/index.js
@@ -130,8 +130,8 @@ Tafgeet.prototype.parse = function () {
     }
   }
   
-  if(this.computedOptions.endtWith) {
-    str += " " + this.computedOptions.endtWith;
+  if(this.computedOptions.endWith) {
+    str += " " + this.computedOptions.endWith;
   }
   return str;
 };

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ Tafgeet.prototype.parse = function () {
     }
   }
 
-  if (this.computedOptions.currency != "") {
+  if (this.computedOptions.currency) {
     if (this.digit >= 3 && this.digit <= 10) {
       str += " " + this.currencies[this.computedOptions.currency].plural;
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,280 @@
+{
+  "name": "tafgeetjs",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tafgeetjs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Converts currency digits into written Arabic words",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -43,16 +43,16 @@ describe('Reading numbers from 1 - 999', function() {
 });
 describe('Reading full amounts without a currecy specified', function() {
     it('should read 7,564,654', function() {
-        assert.equal("فقط سبعة ملايين وخمسمائة وأربعة وستون ألف وستمائة وأربعة وخمسون لا غير", new Tafgeet('7564654', '').parse());
+        assert.equal("فقط سبعة ملايين وخمسمائة وأربعة وستون ألف وستمائة وأربعة وخمسون لا غير", new Tafgeet('7564654', {currency: ''}).parse());
     });
     it('should read 12', function() {
-        assert.equal("فقط أثني عشر لا غير", new Tafgeet('12', '').parse());
+        assert.equal("فقط أثني عشر لا غير", new Tafgeet('12', {currency: ''}).parse());
     });
     it('should read 74', function() {
-        assert.equal("فقط أربعة وسبعون لا غير", new Tafgeet('74', '').parse());
+        assert.equal("فقط أربعة وسبعون لا غير", new Tafgeet('74', {currency: ''}).parse());
     });
     it('should read 234', function() {
-        assert.equal("فقط مائتين وأربعة وثلاثون لا غير", new Tafgeet('234', '').parse());
+        assert.equal("فقط مائتين وأربعة وثلاثون لا غير", new Tafgeet('234', {currency: ''}).parse());
     });
 });
 describe('Reading full amounts', function() {
@@ -63,10 +63,10 @@ describe('Reading full amounts', function() {
         assert.equal("فقط واحد جنيه سوداني وعشرون قرش لا غير", new Tafgeet('1.20').parse());
     });
     it('should read TND 1.200', function() {
-        assert.equal("فقط واحد دينار تونسي ومائتين مليم لا غير", new Tafgeet('1.200', 'TND').parse());
+        assert.equal("فقط واحد دينار تونسي ومائتين مليم لا غير", new Tafgeet('1.200', {currency: 'TND'}).parse());
     });
     it('should read SDG 1.20 even if there are three decimal places', function() {
-        assert.equal("فقط واحد جنيه سوداني وعشرون قرش لا غير", new Tafgeet('1.200', 'SDG').parse());
+        assert.equal("فقط واحد جنيه سوداني وعشرون قرش لا غير", new Tafgeet('1.200', {currency: 'SDG'}).parse());
     });
     it('should read SDG 1,000', function() {
         assert.equal("فقط ألف جنيه سوداني لا غير", new Tafgeet('1000').parse());
@@ -96,7 +96,7 @@ describe('Reading full amounts', function() {
         assert.equal("فقط مليون جنيه سوداني وستة وستون قرش لا غير", new Tafgeet('1000000.66').parse());
     });
     it('should read TND 1,000,000.660', function() {
-        assert.equal("فقط مليون دينار تونسي وستمائة وستون مليم لا غير", new Tafgeet('1000000.660', 'TND').parse());
+        assert.equal("فقط مليون دينار تونسي وستمائة وستون مليم لا غير", new Tafgeet('1000000.660', {currency: 'TND'}).parse());
     });
     it('should read SDG 100,000', function() {
         assert.equal("فقط مائة ألف جنيه سوداني لا غير", new Tafgeet('100000').parse());
@@ -123,10 +123,10 @@ describe('Reading full amounts', function() {
         assert.equal("فقط عشرة مليون وواحد جنيه سوداني لا غير", new Tafgeet('10000001').parse());
     });
     it('should read TND 1,001', function() {
-        assert.equal("فقط ألف وواحد دينار تونسي لا غير", new Tafgeet('1001','TND').parse());
+        assert.equal("فقط ألف وواحد دينار تونسي لا غير", new Tafgeet('1001',{currency: 'TND'}).parse());
     });
     it('should read TND 556,563.999', function() {
-        assert.equal("فقط خمسمائة وستة وخمسون ألف وخمسمائة وثلاثة وستون دينار تونسي وتسعمائة وتسعة وتسعون مليم لا غير", new Tafgeet('556563.999','TND').parse());
+        assert.equal("فقط خمسمائة وستة وخمسون ألف وخمسمائة وثلاثة وستون دينار تونسي وتسعمائة وتسعة وتسعون مليم لا غير", new Tafgeet('556563.999',{currency: 'TND'}).parse());
     });
     it('should read SDG 10,001', function() {
         assert.equal("فقط عشرة ألف وواحد جنيه سوداني لا غير", new Tafgeet('10001').parse());

--- a/test/test.js
+++ b/test/test.js
@@ -43,16 +43,25 @@ describe('Reading numbers from 1 - 999', function() {
 });
 describe('Reading full amounts without a currecy specified', function() {
     it('should read 7,564,654', function() {
-        assert.equal("فقط سبعة ملايين وخمسمائة وأربعة وستون ألف وستمائة وأربعة وخمسون لا غير", new Tafgeet('7564654', {currency: ''}).parse());
+        assert.equal("فقط سبعة ملايين وخمسمائة وأربعة وستون ألف وستمائة وأربعة وخمسون لا غير", new Tafgeet('7564654', {currency: null}).parse());
     });
     it('should read 12', function() {
-        assert.equal("فقط أثني عشر لا غير", new Tafgeet('12', {currency: ''}).parse());
+        assert.equal("فقط أثني عشر لا غير", new Tafgeet('12', {currency: null}).parse());
     });
     it('should read 74', function() {
-        assert.equal("فقط أربعة وسبعون لا غير", new Tafgeet('74', {currency: ''}).parse());
+        assert.equal("فقط أربعة وسبعون لا غير", new Tafgeet('74', {currency: null}).parse());
     });
     it('should read 234', function() {
-        assert.equal("فقط مائتين وأربعة وثلاثون لا غير", new Tafgeet('234', {currency: ''}).parse());
+        assert.equal("فقط مائتين وأربعة وثلاثون لا غير", new Tafgeet('234', {currency: null}).parse());
+    });
+    it('should read 234 without a startWith specified', function() {
+        assert.equal("مائتين وأربعة وثلاثون لا غير", new Tafgeet('234', {currency: null, startWith: null}).parse());
+    });
+    it('should read 234 without a endWith specified', function() {
+        assert.equal("فقط مائتين وأربعة وثلاثون", new Tafgeet('234', {currency: null, endWith: null}).parse());
+    });
+    it('should read 234 without a endWith and startWith specified', function() {
+        assert.equal("مائتين وأربعة وثلاثون", new Tafgeet('234', {currency: null, startWith: null, endWith: null}).parse());
     });
 });
 describe('Reading full amounts', function() {


### PR DESCRIPTION
in this PR:

- support `options` feature
- wrap `currency` option inside the `options` object (the default still `SDG`)
- make the `فقط` text as an option inside `startWith` property (the default is `فقط`)
- make the `لا غير` text as an option inside `endWith` property (the default is `لا غير`)
- make the `currency` and the other options accept `null` as a value
- update package version to 2.2.0
- update README.md file to write the `options` documentation
- add `.gitignore` file to ignore not needed folders/files